### PR TITLE
Create action to search Todoist tasks

### DIFF
--- a/components/todoist/actions/search-tasks/search-tasks.mjs
+++ b/components/todoist/actions/search-tasks/search-tasks.mjs
@@ -1,0 +1,64 @@
+import todoist from "../../todoist.app.mjs";
+
+export default {
+  key: "todoist-search-tasks",
+  name: "Search Tasks",
+  description: "Search tasks by name, label, project and/or section. [See Docs](https://developer.todoist.com/rest/v2/#get-active-tasks)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    todoist,
+    name: {
+      type: "string",
+      label: "Name Match",
+      description: "Returns tasks that contain the specified string in their name.",
+      optional: true,
+      default: "",
+    },
+    label: {
+      propDefinition: [
+        todoist,
+        "label",
+      ],
+    },
+    project: {
+      propDefinition: [
+        todoist,
+        "project",
+      ],
+    },
+    section: {
+      propDefinition: [
+        todoist,
+        "section",
+        (c) => ({
+          project: c.project,
+        }),
+      ],
+    },
+  },
+  async run ({ $ }) {
+    const {
+      name,
+      label,
+      project,
+      section,
+    } = this;
+    const tasks = await this.todoist.getActiveTasks({
+      $,
+      params: {
+        label: label,
+        project_id: project,
+        section_id: section,
+      },
+    });
+    let result = tasks.filter((task) => (task.content).includes(name));
+    let summary = `${result.length} task${result.length == 1
+      ? ""
+      : "s"} found`;
+    $.export("$summary", summary);
+    return result.length > 0
+      ? result
+      : undefined;
+  },
+};


### PR DESCRIPTION
Currently, the only option to search Todoist tasks with a Pipedream action is to use [find-task](https://github.com/PipedreamHQ/pipedream/blob/master/components/todoist/actions/find-task/find-task.mjs). That action is designed to return just 1 single task given an exact name, and create it if it does not exist.

While this is useful for certain scenarios, it does not cover other possible needs (like retrieving all tasks that have a given label). This can be accomplished with the proposed action, which receives some filtering options and returns all the matching tasks from a Todoist account.

